### PR TITLE
Fixed register dob

### DIFF
--- a/src/Components/Utilities/DatePickerInput.jsx
+++ b/src/Components/Utilities/DatePickerInput.jsx
@@ -41,6 +41,8 @@ const DatePickerInput = ({ label, icon, isValid, name, changeFunc, val}) => {
         placeholder="Date of Birth"
         aria-label={label}
         className={styles.no_box_shadow}
+        max= {new Date().toISOString().split("T")[0]}
+        min="1900-01-01"
       />
 
       {!isValid ? (


### PR DESCRIPTION
[Added a max and min limit to the DatePickerInput component to prevent year from overflowing to 6 digits. The current code does not allow the year to exceed beyond 4 digits.